### PR TITLE
rename itemsModel

### DIFF
--- a/js/adapt-blinds.js
+++ b/js/adapt-blinds.js
@@ -1,12 +1,12 @@
 define([
     "core/js/adapt",
-    "core/js/models/itemsModel",
+    "core/js/models/itemModel",
     "./BlindsView"
-], function(Adapt, ItemsModel, BlindsView) {
+], function(Adapt, ItemModel, BlindsView) {
 
     return Adapt.register("blinds", {
         view: BlindsView,
-        model: ItemsModel
+        model: ItemModel
     });
 
 });


### PR DESCRIPTION
renamed to match framework v2.2.5 core/js/models/itemModel.js ("itemModels" vs "itemsModel")