### PR TITLE
Fix framework dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ The attributes listed below are used in *components.json* to configure **Blinds*
 Viewport sizing
 
 ----------------------------
-**Version number:**  1.0
-**Framework versions:**  2.0
+**Version number:**  2.1.1
+**Framework versions:**  3+
 **Author / maintainer:** Dan Storey

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
     "name": "adapt-blinds",
     "repository": "git://github.com/danielstorey/adapt-blinds.git",
-    "framework": "^2.1.0",
-    "version": "2.1.0",
+    "framework": ">=3",
+    "version": "2.1.1",
     "homepage": "https://github.com/danielstorey/adapt-blinds",
     "issues": "https://github.com/danielstorey/adapt-blinds/issues",
     "displayName": "Blinds",


### PR DESCRIPTION
Needed to be bumped ever since https://github.com/danielstorey/adapt-blinds/pull/5/commits/238af108a9f5005e07c10e3002e865e8f2a3159f.

This will avoid it accidently being installed into an authoring tool instance running framework v2.

Resolves #6.